### PR TITLE
Fix issue when performance.now is not defined

### DIFF
--- a/lib/client/store.js
+++ b/lib/client/store.js
@@ -51,7 +51,7 @@ Store.prototype.stop = function() {
 };
 
 Store.prototype.now = function() {
-  if (isPerformanceExists) {
+  if (isPerformanceExists && performance.now) {
     return performance.now();
   }
 


### PR DESCRIPTION
I've had a few error logs indicating that performance.now is not defined (`Uncaught TypeError: Object [object Performance] has no method 'now'`) It's somehow surprising since support looks good (https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) but...
